### PR TITLE
[MODULES-4151] Implement install_module_dependencies_on method to install package dependencies

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,10 +3,28 @@ require: rubocop-rspec
 AllCops:
   TargetRubyVersion: 2.1
 
+Metrics/AbcSize:
+  Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
+Metrics/MethodLength:
+  Enabled: false
+
+Metrics/ModuleLength:
+  Enabled: false
+
+Metrics/PerceivedComplexity:
+  Enabled: false
+
 RSpec/AnyInstance:
   Enabled: false
 
 RSpec/DescribeClass:
+  Enabled: false
+
+RSpec/ExampleLength:
   Enabled: false
 
 RSpec/NestedGroups:

--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ OR
 #####Parameters
 * name - Required. Name of the fact as a string
 * operator - Required. Must be on of 4 supported operators symbols:
-* * :equal
-* * :not_equal
-* * :in
-* * :not_in
+  * :equal
+  * :not_equal
+  * :in
+  * :not_in
 * value - Required. Must be a string if the operator used is :equal or :not_equal. Must be an array if operator is :in or :not_in
 
 ### Support

--- a/README.md
+++ b/README.md
@@ -15,6 +15,23 @@ require 'beaker/module_install_helper'
 install_module_on(host)
 ```
 
+This example will install git on 2 hosts. If osfamily fact equals 'RedHat' the package named git will be installed. Likewise for Debian, the git-core package will be installed.
+```ruby
+hosts = [a_debian_beaker_host, a_redhat_beaker_host]
+dependencies =
+    [{
+         name:  'git',
+         type:  :package,
+         facts: [{ name: 'osfamily', operator: :equal, value: 'RedHat' }]
+     }, {
+        name:  'git-core',
+        type:  :package,
+        facts: [{ name: 'osfamily', operator: :equal, value: 'Debian' }]
+    }]
+    
+    install_module_dependencies_on(hosts, dependencies)
+```
+
 ### Assumptions
 * Module under test has a valid metadata.json file at the root of the module directory.
 
@@ -24,11 +41,36 @@ This will call `install_module_on` on the hosts with role 'master'. If there are
 ### `install_module_on(host)`
 This will install the module under test on the specified host using the local source. The module name will be derived from the name property of the module's metadata.json file, assuming it is in format author-modulename.
 
-### `install_module_dependencies_on`
-This will install a list of dependencies on the specified host either from forge or github, depending on the specified dependencies
+### `install_module_dependencies_on(hosts, dependencies)`
+This will install a list of dependencies on the specified host either from forge or github, depending on the specified dependencies. See below [Dependency Format](####Dependency Format) section and [Fact Constrain Format](####Fact Constrain Format) section for details on how to format the given dependencies.
+#### Dependency Format
+Dependencies must be specified to `install_module_dependencies_on` as either a hash of a single dependency or an array of dependencies in a valid dependency format as defined below, here is an example:
+```ruby
+{ name: 'git', type: :package, facts: []}
+```
+#####Paramters
+* name - Required. Name of the dependency
+* type - Required. Currently only :package type supported. Uses beakers `install_package` method to perform package install using the dependencies name attribute
+* facts - Optional. If specified, must be array of valid fact constraint hashes.
+
+#### Fact Constrain Format
+Below is an example of a fact constraint hash that can be specified as an array of hashes inside a dependency hash.
+```ruby
+{ name: 'osfamily', operator: :equal, value: 'RedHat' }
+OR
+{ name: 'osfamily', operator: :not_in, value: ['RedHat', 'Debian'] }
+```
+#####Parameters
+* name - Required. Name of the fact as a string
+* operator - Required. Must be on of 4 supported operators symbols:
+* * :equal
+* * :not_equal
+* * :in
+* * :not_in
+* value - Required. Must be a string if the operator used is :equal or :not_equal. Must be an array if operator is :in or :not_in
 
 ### Support
 No support is supplied or implied. Use at your own risk.
 
 ### TODO
- - Implement `install_module_dependencies_on`
+ * Implement :module dependency type for the `install_module_dependencies_on` method to install a dependant module

--- a/lib/beaker/module_install_helper.rb
+++ b/lib/beaker/module_install_helper.rb
@@ -11,8 +11,8 @@ module Beaker::ModuleInstallHelper
     install_module_on hosts_to_install_module_on
   end
 
-  # This method will install the module under test on the specified host(s) from
-  # the source on the local machine
+  # This method will install the module under test on the
+  # specified host(s) from the source on the local machine
   def install_module_on(host)
     copy_module_to(host,
                    source:      @module_source_dir,
@@ -20,9 +20,114 @@ module Beaker::ModuleInstallHelper
   end
 
   # This method will install the module under tests dependencies on the
-  # specified host
-  def install_module_dependencies_on(_host, _dependencies)
-    raise 'Not Implemented Yet'
+  # specified host(s)
+  def install_module_dependencies_on(hosts, dependencies)
+    dependencies = [dependencies] if dependencies.is_a?(Hash)
+
+    if !dependencies.is_a?(Array) ||
+       dependencies.any? { |dependency| !valid_dependency?(dependency) }
+      raise 'Invalid dependencies supplied'
+    end
+
+    hosts = [hosts] unless hosts.is_a?(Array)
+    hosts.each do |host|
+      dependencies.each do |dependency|
+        if meets_dependency?(host, dependency)
+          install_dependency_on(host, dependency)
+        end
+      end
+    end
+  end
+
+  # Validates the given dependency is valid and the returns true/false depending
+  # on whether or not the given beaker host meets the given dependency fact
+  # requirements. If no facts, always returns true.
+  def meets_dependency?(host, dep)
+    raise 'Invalid dependency' unless valid_dependency?(dep)
+
+    # If no facts or any facts are valid, return true. Otherwise, return false
+    return true unless dep.key?(:facts)
+    return true if dep[:facts].any? { |fc| meets_fact_constraint?(host, fc) }
+    false
+  end
+
+  # Validates the given fact constraint is valid and returns true/false
+  # depending on whether or not the given beaker host meets the given
+  # fact constraint
+  def meets_fact_constraint?(host, fc)
+    raise 'Invalid fact constraint' unless valid_fact_constraint?(fc)
+    fact_value = fact_on(host, fc[:name])
+    case fc[:operator]
+    when :equal
+      return fact_value == fc[:value]
+    when :not_equal
+      return fact_value != fc[:value]
+    when :in
+      return fc[:value].include?(fact_value)
+    when :not_in
+      return !fc[:value].include?(fact_value)
+    else
+      return false
+    end
+  end
+
+  # This method performs the install of a dependency on the given beaker host.
+  # Assumes the dependency given is valid and dependency type is :package, as
+  # this is the only supported package type.
+  def install_dependency_on(host, dependency)
+    case dependency[:type]
+    when :package
+      install_package(host, dependency[:name])
+    else
+      raise "#{dependency[:type]} not yet supported"
+    end
+  end
+
+  # Will return true/false depending on whether the given dependency is valid.
+  # Dependency must be a hash in format { name: '', type: :package }. The
+  # dependency may optionally contain an array of facts with the key, :facts
+  def valid_dependency?(dependency)
+    # Ensure its a hash and necessary keys exist in the hash
+    return false unless dependency.is_a?(Hash)
+    return false unless dependency.key?(:name) && dependency.key?(:type)
+
+    # Ensure the type is in the specified list of dependency types supported
+    return false unless [:package].include?(dependency[:type])
+
+    # If fact constraints are specified for the dependency, ensure they're valid
+    if dependency.key?(:facts)
+      return false unless dependency[:facts].is_a?(Array)
+      dependency[:facts].each do |fact_constraint|
+        return false unless valid_fact_constraint?(fact_constraint)
+      end
+    end
+    true
+  end
+
+  # Will return true/false depending on whether the given fact_constraint is a
+  # hash in format { name: '', operator: :equal, value: 'val' OR ['val','val'] }
+  def valid_fact_constraint?(fact_constraint)
+    # Ensure its a hash and necessary keys exist in the hash
+    return false unless fact_constraint.is_a?(Hash) &&
+                        fact_constraint.key?(:name) &&
+                        fact_constraint.key?(:operator) &&
+                        fact_constraint.key?(:value)
+
+    # Ensure parameter types are correct, name is a string, operator in
+    # specified list and value correct type depending on operator
+    return false unless fact_constraint[:name].is_a?(String) &&
+                        [:equal,
+                         :not_equal,
+                         :in,
+                         :not_in].include?(fact_constraint[:operator])
+
+    return false if [:in, :not_in].include?(fact_constraint[:operator]) &&
+                    !fact_constraint[:value].is_a?(Array)
+
+    return false if [:equal, :not_equal].include?(fact_constraint[:operator]) &&
+                    !fact_constraint[:value].is_a?(String)
+
+    true
   end
 
   # This method will return array of all masters. If no masters exist, it will

--- a/spec/unit/beaker/module_install_helper_spec.rb
+++ b/spec/unit/beaker/module_install_helper_spec.rb
@@ -93,10 +93,430 @@ describe Beaker::ModuleInstallHelper do
     end
   end
 
+  context 'is_valid_dependency' do
+    context 'with valid parameters' do
+      context 'without facts specified' do
+        let(:dependency) do
+          {
+            name:  'git',
+            type:  :package
+          }
+        end
+
+        it 'returns true' do
+          expect(valid_dependency?(dependency)).to be true
+        end
+      end
+
+      context 'with valid facts specified' do
+        let(:dependency) do
+          {
+            name:  'git',
+            type:  :package,
+            facts: [{ name: 'osfamily', operator: :equal, value: 'RedHat' }]
+          }
+        end
+
+        it 'returns true' do
+          expect(valid_dependency?(dependency)).to be true
+        end
+      end
+    end
+
+    context 'without a name specified' do
+      let(:dependency) do
+        {
+          type:  :package
+        }
+      end
+
+      it 'returns false' do
+        expect(valid_dependency?(dependency)).to be false
+      end
+    end
+    context 'without a type specified' do
+      let(:dependency) do
+        {
+          name:  'git'
+        }
+      end
+
+      it 'returns false' do
+        expect(valid_dependency?(dependency)).to be false
+      end
+    end
+  end
+
+  context 'is_valid_fact_constraint' do
+    context 'with valid parameters' do
+      let(:fact_constraint) do
+        { name: 'osfamily',
+          operator: :equal,
+          value: 'RedHat' }
+      end
+
+      it 'returns true' do
+        expect(valid_fact_constraint?(fact_constraint)).to be true
+      end
+    end
+
+    context 'with missing parameter' do
+      let(:fact_constraint) do
+        { operator: :equal,
+          value: 'RedHat' }
+      end
+
+      it 'returns false' do
+        expect(valid_fact_constraint?(fact_constraint)).to be false
+      end
+    end
+
+    context 'without invalid operator' do
+      let(:fact_constraint) do
+        { name: 'osfamily',
+          operator: :equal_wrong,
+          value: 'RedHat' }
+      end
+
+      it 'returns false' do
+        expect(valid_fact_constraint?(fact_constraint)).to be false
+      end
+    end
+
+    context 'without invalid value' do
+      context 'using in operator' do
+        let(:fact_constraint) do
+          { name: 'osfamily',
+            operator: :equal,
+            value: ['Test'] }
+        end
+
+        it 'returns false' do
+          expect(valid_fact_constraint?(fact_constraint)).to be false
+        end
+      end
+
+      context 'using equal operator' do
+        let(:fact_constraint) do
+          { name: 'osfamily',
+            operator: :in,
+            value: 'RedHat' }
+        end
+
+        it 'returns false' do
+          expect(valid_fact_constraint?(fact_constraint)).to be false
+        end
+      end
+    end
+  end
+
+  context 'host_meets_fact_constraint' do
+    context 'host meets fact constraint' do
+      context 'using equal operator' do
+        let(:fact_constraint) do
+          { name: 'osfamily',
+            operator: :equal,
+            value: 'RedHat' }
+        end
+
+        it 'returns true' do
+          allow_any_instance_of(Beaker::DSL::Helpers::FacterHelpers)
+            .to receive(:fact_on)
+            .with(nil, 'osfamily')
+            .and_return('RedHat')
+
+          expect(meets_fact_constraint?(nil, fact_constraint)).to be true
+        end
+      end
+
+      context 'using not_equal operator' do
+        let(:fact_constraint) do
+          { name: 'osfamily',
+            operator: :not_equal,
+            value: 'Debian' }
+        end
+
+        it 'returns true' do
+          allow_any_instance_of(Beaker::DSL::Helpers::FacterHelpers)
+            .to receive(:fact_on)
+            .with(nil, 'osfamily')
+            .and_return('RedHat')
+
+          expect(meets_fact_constraint?(nil, fact_constraint)).to be true
+        end
+      end
+
+      context 'using in operator' do
+        let(:fact_constraint) do
+          { name: 'osfamily',
+            operator: :in,
+            value: %w(RedHat Debian) }
+        end
+
+        it 'returns true' do
+          allow_any_instance_of(Beaker::DSL::Helpers::FacterHelpers)
+            .to receive(:fact_on)
+            .with(nil, 'osfamily')
+            .and_return('RedHat')
+
+          expect(meets_fact_constraint?(nil, fact_constraint)).to be true
+        end
+      end
+
+      context 'using not_in operator' do
+        let(:fact_constraint) do
+          { name: 'osfamily',
+            operator: :not_in,
+            value: %w(SLES Debian) }
+        end
+
+        it 'returns true' do
+          allow_any_instance_of(Beaker::DSL::Helpers::FacterHelpers)
+            .to receive(:fact_on)
+            .with(nil, 'osfamily')
+            .and_return('RedHat')
+
+          expect(meets_fact_constraint?(nil, fact_constraint)).to be true
+        end
+      end
+    end
+
+    context 'host does not meet fact constraint' do
+      context 'using equal operator' do
+        let(:fact_constraint) do
+          { name: 'osfamily',
+            operator: :equal,
+            value: 'RedHat' }
+        end
+
+        it 'returns false' do
+          allow_any_instance_of(Beaker::DSL::Helpers::FacterHelpers)
+            .to receive(:fact_on)
+            .with(nil, 'osfamily')
+            .and_return('Debian')
+
+          expect(meets_fact_constraint?(nil, fact_constraint)).to be false
+        end
+      end
+
+      context 'using not_equal operator' do
+        let(:fact_constraint) do
+          { name: 'osfamily',
+            operator: :not_equal,
+            value: 'Debian' }
+        end
+
+        it 'returns false' do
+          allow_any_instance_of(Beaker::DSL::Helpers::FacterHelpers)
+            .to receive(:fact_on)
+            .with(nil, 'osfamily')
+            .and_return('Debian')
+
+          expect(meets_fact_constraint?(nil, fact_constraint)).to be false
+        end
+      end
+
+      context 'using in operator' do
+        let(:fact_constraint) do
+          { name: 'osfamily',
+            operator: :in,
+            value: %w(RedHat SLES) }
+        end
+
+        it 'returns false' do
+          allow_any_instance_of(Beaker::DSL::Helpers::FacterHelpers)
+            .to receive(:fact_on)
+            .with(nil, 'osfamily')
+            .and_return('Debian')
+
+          expect(meets_fact_constraint?(nil, fact_constraint)).to be false
+        end
+      end
+
+      context 'using not_in operator' do
+        let(:fact_constraint) do
+          { name: 'osfamily',
+            operator: :not_in,
+            value: %w(SLES Debian) }
+        end
+
+        it 'returns false' do
+          allow_any_instance_of(Beaker::DSL::Helpers::FacterHelpers)
+            .to receive(:fact_on)
+            .with(nil, 'osfamily')
+            .and_return('Debian')
+
+          expect(meets_fact_constraint?(nil, fact_constraint)).to be false
+        end
+      end
+    end
+  end
+
+  context 'host_meets_dependency' do
+    context 'host meets dependency' do
+      context 'no facts specified' do
+        let(:dependency) { { name: 'git', type: :package } }
+
+        it 'returns true' do
+          expect(meets_dependency?(nil, dependency)).to be true
+        end
+      end
+
+      context '2 valid facts specified' do
+        let(:dependency) do
+          { name: 'git', type: :package, facts: [
+            { name: 'osfamily', operator: :equal, value: 'RedHat' },
+            { name: 'some_fact', operator: :equal, value: 'SomeVal' }
+          ] }
+        end
+
+        it 'returns true' do
+          allow_any_instance_of(Beaker::DSL::Helpers::FacterHelpers)
+            .to receive(:fact_on)
+            .with(nil, 'osfamily')
+            .and_return('RedHat')
+
+          allow_any_instance_of(Beaker::DSL::Helpers::FacterHelpers)
+            .to receive(:fact_on)
+            .with(nil, 'some_fact')
+            .and_return('SomeVal')
+
+          expect(meets_dependency?(nil, dependency)).to be true
+        end
+      end
+
+      context '1 valid fact and 1 invalid fact specified' do
+        let(:dependency) do
+          { name: 'git', type: :package, facts: [
+            { name: 'osfamily', operator: :equal, value: 'RedHat' },
+            { name: 'some_fact', operator: :equal, value: 'SomeWrongVal' }
+          ] }
+        end
+
+        it 'returns true' do
+          allow_any_instance_of(Beaker::DSL::Helpers::FacterHelpers)
+            .to receive(:fact_on)
+            .with(nil, 'osfamily')
+            .and_return('RedHat')
+
+          allow_any_instance_of(Beaker::DSL::Helpers::FacterHelpers)
+            .to receive(:fact_on)
+            .with(nil, 'some_fact')
+            .and_return('SomeVal')
+
+          expect(meets_dependency?(nil, dependency)).to be true
+        end
+      end
+    end
+
+    context 'host does not meet dependency with 2 invalid facts specified' do
+      let(:dependency) do
+        { name: 'git', type: :package, facts: [
+          { name: 'osfamily', operator: :equal, value: 'Debian' },
+          { name: 'some_fact', operator: :equal, value: 'SomeWrongVal' }
+        ] }
+      end
+
+      it 'returns false' do
+        allow_any_instance_of(Beaker::DSL::Helpers::FacterHelpers)
+          .to receive(:fact_on)
+          .with(nil, 'osfamily')
+          .and_return('RedHat')
+
+        allow_any_instance_of(Beaker::DSL::Helpers::FacterHelpers)
+          .to receive(:fact_on)
+          .with(nil, 'some_fact')
+          .and_return('SomeVal')
+
+        expect(meets_dependency?(nil, dependency)).to be false
+      end
+    end
+  end
+
   context 'install_module_dependencies_on' do
-    it 'raises not implemented error' do
-      expect { install_module_dependencies_on(nil, nil) }
-        .to raise_error /Not Implemented Yet/
+    context 'single dependency single host' do
+      context 'no fact constraints supplied' do
+        let(:host) { { name: 'ahost' } }
+        let(:dependency) { { name: 'git', type: :package } }
+
+        it 'calls install_package with single host and single package' do
+          expect_any_instance_of(Beaker::DSL::Helpers::HostHelpers)
+            .to receive(:install_package)
+            .with(host, dependency[:name])
+            .exactly(1)
+
+          install_module_dependencies_on(host, dependency)
+        end
+      end
+
+      context 'with fact constraints supplied' do
+        let(:host) { { name: 'ahost' } }
+        let(:dependency) do
+          {
+            name: 'git',
+            type: :package,
+            facts: [{ name: 'osfamily', operator: :equal, value: 'RedHat' }]
+          }
+        end
+
+        it 'calls install_package with single host and single package' do
+          allow_any_instance_of(Beaker::DSL::Helpers::FacterHelpers)
+            .to receive(:fact_on)
+            .with(host, 'osfamily')
+            .and_return('RedHat')
+
+          expect_any_instance_of(Beaker::DSL::Helpers::HostHelpers)
+            .to receive(:install_package)
+            .with(host, dependency[:name])
+            .exactly(1)
+
+          install_module_dependencies_on(host, dependency)
+        end
+      end
+    end
+
+    context 'multiple dependencies and multiple hosts' do
+      let(:redhat_host) { { name: 'redhat_host' } }
+      let(:debian_host) { { name: 'debian_host' } }
+      let(:git_dependency) do
+        {
+          name: 'git',
+          type: :package,
+          facts: [{ name: 'osfamily', operator: :equal, value: 'RedHat' }]
+        }
+      end
+      let(:gitcore_dependency) do
+        {
+          name: 'git-core',
+          type: :package,
+          facts: [{ name: 'osfamily', operator: :equal, value: 'Debian' }]
+        }
+      end
+
+      it 'calls install_package once for each host' do
+        allow_any_instance_of(Beaker::DSL::Helpers::FacterHelpers)
+          .to receive(:fact_on)
+          .with(redhat_host, 'osfamily')
+          .and_return('RedHat')
+
+        allow_any_instance_of(Beaker::DSL::Helpers::FacterHelpers)
+          .to receive(:fact_on)
+          .with(debian_host, 'osfamily')
+          .and_return('Debian')
+
+        expect_any_instance_of(Beaker::DSL::Helpers::HostHelpers)
+          .to receive(:install_package)
+          .with(redhat_host, git_dependency[:name])
+          .exactly(1)
+
+        expect_any_instance_of(Beaker::DSL::Helpers::HostHelpers)
+          .to receive(:install_package)
+          .with(debian_host, gitcore_dependency[:name])
+          .exactly(1)
+
+        install_module_dependencies_on([redhat_host, debian_host],
+                                       [git_dependency, gitcore_dependency])
+      end
     end
   end
 end


### PR DESCRIPTION
This PR implements install_module_dependencies_on method which installs a list of dependencies on a given list of hosts, if the hosts meet any given fact constraints within each dependency.