### PR TITLE
Release 0.1.1 containing fixes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,9 @@ Lint/AmbiguousRegexpLiteral:
 Style/ClassAndModuleChildren:
   Enabled: false
 
+Style/GlobalVars:
+  Enabled: false
+
 Bundler/DuplicatedGem:
   Enabled: false
 

--- a/beaker-module_install_helper.gemspec
+++ b/beaker-module_install_helper.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'beaker-module_install_helper'
-  spec.version       = '0.1.0'
+  spec.version       = '0.1.1'
   spec.authors       = ['Puppet']
   spec.email         = ['wilson@puppet.com']
 

--- a/lib/beaker/module_install_helper.rb
+++ b/lib/beaker/module_install_helper.rb
@@ -70,7 +70,7 @@ module Beaker::ModuleInstallHelper
 
     # Here we iterate the releases of the given module and pick the most recent
     # that matches to version requirement
-    forge_data['releases'].sort_by { |k| k['version'] }.reverse.each do |rel|
+    forge_data['releases'].each do |rel|
       return rel['version'] if vrs.all? { |vr| vr.match?('', rel['version']) }
     end
 

--- a/lib/beaker/module_install_helper.rb
+++ b/lib/beaker/module_install_helper.rb
@@ -22,17 +22,18 @@ module Beaker::ModuleInstallHelper
   # This method calls the install_module_dependencies_on method for each
   # host which is a master, or if no master is present, on all agent nodes.
   def install_module_dependencies
-    hosts_to_install_module_on.each do |host|
-      install_module_dependencies_on(host)
-    end
+    install_module_dependencies_on(host)
   end
 
   # This method will install the module under tests module dependencies on the
   # specified host from the dependencies list in metadata.json
   def install_module_dependencies_on(host)
+    host = [host] if host.is_a?(Hash)
     deps = module_dependencies_from_metadata
-    deps.each do |dep|
-      install_puppet_module_via_pmt_on(host, dep)
+    host.each do |hst|
+      deps.each do |dep|
+        install_puppet_module_via_pmt_on(hst, dep)
+      end
     end
   end
 

--- a/lib/beaker/module_install_helper.rb
+++ b/lib/beaker/module_install_helper.rb
@@ -15,7 +15,7 @@ module Beaker::ModuleInstallHelper
   # the source on the local machine
   def install_module_on(host)
     copy_module_to(host,
-                   source:      @module_source_dir,
+                   source:      $module_source_dir,
                    module_name: module_name_from_metadata)
   end
 
@@ -121,9 +121,9 @@ module Beaker::ModuleInstallHelper
   # This method uses the module_source_directory path to read the metadata.json
   # file into a json array
   def module_metadata
-    metadata_path = "#{@module_source_dir}/metadata.json"
+    metadata_path = "#{$module_source_dir}/metadata.json"
     unless File.exist?(metadata_path)
-      raise "Error loading metadata.json file from #{@module_source_dir}"
+      raise "Error loading metadata.json file from #{$module_source_dir}"
     end
     JSON.parse(File.read(metadata_path))
   end
@@ -148,4 +148,4 @@ end
 
 include Beaker::ModuleInstallHelper
 # Use the caller (requirer) of this file to begin search for module source dir
-@module_source_dir = get_module_source_directory caller[0][/[^:]+/]
+$module_source_dir = get_module_source_directory caller[0][/[^:]+/]

--- a/spec/unit/beaker/module_install_helper_spec.rb
+++ b/spec/unit/beaker/module_install_helper_spec.rb
@@ -35,7 +35,7 @@ describe Beaker::ModuleInstallHelper do
 
   context 'module_metadata' do
     before do
-      @module_source_dir = '/a/b/c/d'
+      $module_source_dir = '/a/b/c/d'
       allow(File).to receive(:exist?)
         .with('/a/b/c/d/metadata.json')
         .and_return(true)
@@ -71,7 +71,7 @@ describe Beaker::ModuleInstallHelper do
     let(:module_source_dir) { '/a/b/c/d' }
 
     before do
-      @module_source_dir = '/a/b/c/d'
+      $module_source_dir = '/a/b/c/d'
       allow(File).to receive(:exist?).and_return(true)
       allow(File).to receive(:read).and_return('{"name": "puppetlabs-vcsrepo"}')
 


### PR DESCRIPTION
During implementation I ran into an issue which is described below in the 3rd point that did not happen when using the local development copy within modules spec_helper_acceptance.rb file, only the gem from rubygems after release. This issue makes the gem unuseable. I am unsure of the cause of the issue however have a fix. I made 2 other small changes described in bullets 1 and 2 below.

1. Fix an issue with sorting release versions of module from forge api. Forge api returns module releases in order newest to oldest. We were applying sorting to this list of version (string) descending. However because this is a semver string for example '1.9' is higher in list than '1.12', and hence latest version on module which matches a dependency is sometimes not returned.
2. Bring `install_module_dependencies_on` into line with `install_module_on` by accepting either a single host or an array of multiple hosts
3. Use a global variable to store `@module_source_dir` instead of an instance variable. When 0.1.0 went on to rubygems I began to implement in a number of modules. The module_source_dir variable is set when the module is required from the spec_helper_acceptance.rb file, however when it was then being used when `install_module_dependencies_on` or `install_module_on` is called, its value is nil. This did not occur when I was using the local dev copy of beaker-module_install_helper, only when I required the gem from rubygems after release and I am still currently unsure why.
4. Version bump for this release of bug fixes