### PR TITLE
[MODULES-4312] Install modules dependencies from alternative forge instances and install modules not specified in metadata.json

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,9 @@ require: rubocop-rspec
 AllCops:
   TargetRubyVersion: 2.1
 
+Bundler/OrderedGems:
+  Enabled: false
+
 RSpec/AnyInstance:
   Enabled: false
 
@@ -21,14 +24,23 @@ Style/ClassAndModuleChildren:
 Style/GlobalVars:
   Enabled: false
 
+Style/RegexpLiteral:
+  Enabled: false
+
 Bundler/DuplicatedGem:
   Enabled: false
 
 Metrics/AbcSize:
   Enabled: false
 
+Metrics/BlockLength:
+  Enabled: false
+
 Metrics/LineLength:
   Max: 100
 
 Metrics/MethodLength:
+  Enabled: false
+
+Metrics/ModuleLength:
   Enabled: false

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ The below example will install the module from source on the host with role 'mas
 require 'beaker/module_install_helper'
 install_module_dependencies
 install_module
+
+# Install a testing only dependency, not specified in metadata
+install_module_from_forge('puppetlabs-inifile', '>= 1.0.0 <= 50.0.0')
 ```
 
 The below example will install the module from source on the specified host and install module dependencies specified in metadata.json on the host
@@ -31,6 +34,24 @@ This will call `install_module_dependencies_on` on the hosts with role 'master'.
 
 ### `install_module_dependencies_on`
 This will install a list of dependencies on the specified host from the forge, using the dependencies list specified in the metadata.json file, taking into consideration the version constraints if specified.
+
+**See: ** [Alternative Forge Instances](#alternative-forge-instances)
+
+### `install_module_from_forge(module_name, version_requirement)`
+This will call `install_module_from_forge_on` on the hosts with role 'master'. If there are none, the module will be install on all hosts with the role 'agent', again, if there are none, the module will be installed on all hosts.
+
+### `install_module_from_forge_on(hosts, module_name, version_requirement)`
+This will install a module from the forge on the given host(s). Module name must be specified in the {author}-{module_name} or {author}/{module_name} format. Version requirement must be specified to meet [this](https://docs.puppet.com/puppet/latest/modules_metadata.html#version-specifiers) criteria.
+ 
+**See: ** [Alternative Forge Instances](#alternative-forge-instances)
+
+### Alternative Forge Instances
+It is possible to use alternative forge instances rather than the production forge instance to install module dependencies by specifiying 2 environment variables, `BEAKER_FORGE_HOST` and `BEAKER_FORGE_API`. Both of these are required as the forge API is used under the hood to resolve version requirement boundary strings.
+
+**Example Using Staging Forge**
+```
+BEAKER_FORGE_HOST=https://module-staging.puppetlabs.com BEAKER_FORGE_API=https://api-module-staging.puppetlabs.com BEAKER_debug=true bundle exec rspec spec/acceptance
+```
 
 ### Support
 No support is supplied or implied. Use at your own risk.


### PR DESCRIPTION
This PR adds ability to specify forge instance using BEAKER_FORGE_HOST and BEAKER_FORGE_API environment variables. BEAKER_FORGE_API is used by this gem to determine the module version to install based on version requirement boundary string and BEAKER_FORGE_HOST is used by beaker itself to do the actual install of the specified module. Beaker does this by using puppet to add a host record to redirect forge.puppetlabs.com to the resolved ip of the specified BEAKER_FORGE_HOST.

This PR also adds the ability to install modules that are not specified in the module metadata.json file. This is useful for installing dependencies not required by the module but for the test suite to run. The `install_module_from_forge_on(hosts, module_name, version_requirement)` method was implemented and documented.

Also included some .rubocop.yml fixes as necessary.