### PR TITLE
Fix beaker forge api not specified error

### DIFF
--- a/beaker-module_install_helper.gemspec
+++ b/beaker-module_install_helper.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'beaker-module_install_helper'
-  spec.version       = '0.1.2'
+  spec.version       = '0.1.3'
   spec.authors       = ['Puppet']
   spec.email         = ['wilson@puppet.com']
 

--- a/lib/beaker/module_install_helper.rb
+++ b/lib/beaker/module_install_helper.rb
@@ -86,7 +86,7 @@ module Beaker::ModuleInstallHelper
   # and upper bounds. The function then uses the forge rest endpoint to find
   # the most recent release of the given module matching the version requirement
   def module_version_from_requirement(mod_name, vr_str)
-    uri = URI("#{forge_api}/v3/modules/#{mod_name}")
+    uri = URI("#{forge_api}v3/modules/#{mod_name}")
     response = Net::HTTP.get(uri)
     forge_data = JSON.parse(response)
 
@@ -170,18 +170,24 @@ module Beaker::ModuleInstallHelper
 
   def forge_host
     fh = ENV['BEAKER_FORGE_HOST']
-    return fh unless fh.nil?
+    unless fh.nil?
+      fh = 'https://' + fh if fh !~ /^(https:\/\/|http:\/\/)/i
+      fh += '/' unless fh != /\/$/
+      return fh
+    end
+
     'https://forge.puppet.com/'
   end
 
   def forge_api
-    fh = forge_host
-    return 'https://forgeapi.puppetlabs.com' if fh == 'https://forge.puppet.com/'
-
     fa = ENV['BEAKER_FORGE_API']
-    return fa.gsub(/\/$/, '') unless fa.nil?
+    unless fa.nil?
+      fa = 'https://' + fa if fa !~ /^(https:\/\/|http:\/\/)/i
+      fa += '/' unless fa != /\/$/
+      return fa
+    end
 
-    raise 'Must specify BEAKER_FORGE_API env variable when specifying custom forge host'
+    'https://forgeapi.puppetlabs.com/'
   end
 end
 

--- a/spec/unit/beaker/module_install_helper_spec.rb
+++ b/spec/unit/beaker/module_install_helper_spec.rb
@@ -242,27 +242,16 @@ describe Beaker::ModuleInstallHelper do
         allow(ENV).to receive(:[]).with('BEAKER_FORGE_HOST').and_return(nil)
         allow(ENV).to receive(:[]).with('BEAKER_FORGE_API').and_return(nil)
 
-        expect(forge_api).to eq('https://forgeapi.puppetlabs.com')
+        expect(forge_api).to eq('https://forgeapi.puppetlabs.com/')
       end
     end
 
     context 'with BEAKER_FORGE_HOST and BEAKER_FORGE_API env variables specified' do
-      context 'without trailing slash' do
-        it 'returns specified forge api' do
-          allow(ENV).to receive(:[]).with('BEAKER_FORGE_HOST').and_return('custom')
-          allow(ENV).to receive(:[]).with('BEAKER_FORGE_API').and_return('an-api-url')
+      it 'returns specified forge api with trailing slash' do
+        allow(ENV).to receive(:[]).with('BEAKER_FORGE_HOST').and_return('custom')
+        allow(ENV).to receive(:[]).with('BEAKER_FORGE_API').and_return('an-api-url/')
 
-          expect(forge_api).to eq('an-api-url')
-        end
-      end
-
-      context 'with trailing slash' do
-        it 'returns specified forge api without trailing slash' do
-          allow(ENV).to receive(:[]).with('BEAKER_FORGE_HOST').and_return('custom')
-          allow(ENV).to receive(:[]).with('BEAKER_FORGE_API').and_return('an-api-url/')
-
-          expect(forge_api).to eq('an-api-url')
-        end
+        expect(forge_api).to eq('https://an-api-url/')
       end
     end
   end


### PR DESCRIPTION
This PR has 2 commits:
 - Do not raise error when BEAKER_FORGE_API is not defined, falls back to production forge API and added sanitisation of forge_host and forge_api url's to ensure they are formatted consistently.
 - Version bump for a minor fix release.