### PR TITLE
Fix get_module_source_directory when module used with Rototiller

### DIFF
--- a/beaker-module_install_helper.gemspec
+++ b/beaker-module_install_helper.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'beaker-module_install_helper'
-  spec.version       = '0.1.3'
+  spec.version       = '0.1.4'
   spec.authors       = ['Puppet']
   spec.email         = ['wilson@puppet.com']
 

--- a/lib/beaker/module_install_helper.rb
+++ b/lib/beaker/module_install_helper.rb
@@ -153,7 +153,14 @@ module Beaker::ModuleInstallHelper
 
   # Use this property to store the module_source_dir, so we don't traverse
   # the tree every time
-  def get_module_source_directory(search_in)
+  def get_module_source_directory(call_stack)
+    matching_caller = call_stack.select { |i| i =~ /(spec_helper_acceptance|_spec)/i }
+
+    raise 'Error finding module source directory' if matching_caller.empty?
+
+    matching_caller = matching_caller[0] if matching_caller.is_a?(Array)
+    search_in = matching_caller[/[^:]+/]
+
     module_source_dir = nil
     # here we go up the file tree and search the directories for a
     # valid metadata.json
@@ -193,4 +200,4 @@ end
 
 include Beaker::ModuleInstallHelper
 # Use the caller (requirer) of this file to begin search for module source dir
-$module_source_dir = get_module_source_directory caller[0][/[^:]+/]
+$module_source_dir = get_module_source_directory caller

--- a/spec/unit/beaker/module_install_helper_spec.rb
+++ b/spec/unit/beaker/module_install_helper_spec.rb
@@ -50,8 +50,8 @@ describe Beaker::ModuleInstallHelper do
   end
 
   context 'get_module_source_directory' do
-    let(:search_in) { '/a/b/c/d/e/f/g/h.rb' }
-    let(:search_in_no_metadata) { '/test/test/test/blah.rb' }
+    let(:call_stack) { ['/a/b/c/d/e/f/g/spec_helper_acceptance.rb'] }
+    let(:call_stack_no_metadata) { ['/test/test/test/spec_helper_acceptance.rb'] }
 
     before do
       allow(File).to receive(:exist?).with(anything).and_return(false)
@@ -59,11 +59,11 @@ describe Beaker::ModuleInstallHelper do
     end
 
     it 'traverses file tree until it finds a folder containing metadata.json' do
-      expect(get_module_source_directory(search_in)).to eq('/a')
+      expect(get_module_source_directory(call_stack)).to eq('/a')
     end
 
     it 'traverses file tree without a metadata.json file' do
-      expect(get_module_source_directory(search_in_no_metadata)).to be_nil
+      expect(get_module_source_directory(call_stack_no_metadata)).to be_nil
     end
   end
 


### PR DESCRIPTION
This is done using by searching the call stack which has required the library for any caller matching `/spec_helper_acceptance/i` to use to search for metadata.json

Also includes a z version bump commit for a minor fix release.