### PR TITLE
Fix bug that causes a NoMethodError: undefined method `each' for nil:NilClass

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 require 'bundler/gem_tasks'
-task default: [:lint, :spec]
+task default: %i[lint spec]
 
 require 'rubocop/rake_task'
 desc 'Run rubocop'

--- a/beaker-module_install_helper.gemspec
+++ b/beaker-module_install_helper.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 

--- a/lib/beaker/module_install_helper.rb
+++ b/lib/beaker/module_install_helper.rb
@@ -69,7 +69,7 @@ module Beaker::ModuleInstallHelper
 
     dependencies = []
     metadata['dependencies'].each do |d|
-      tmp = { module_name: d['name'].sub!('/', '-') }
+      tmp = { module_name: d['name'].sub('/', '-') }
 
       if d.key?('version_requirement')
         tmp[:version] = module_version_from_requirement(tmp[:module_name],

--- a/spec/unit/beaker/module_install_helper_spec.rb
+++ b/spec/unit/beaker/module_install_helper_spec.rb
@@ -5,7 +5,7 @@ describe Beaker::ModuleInstallHelper do
     context 'on split master/agent setup' do
       let(:hosts) do
         [
-          { 'roles' => %w(master database dashboard classifier) },
+          { 'roles' => %w[master database dashboard classifier] },
           { 'roles' => ['agent'] }
         ]
       end
@@ -69,6 +69,7 @@ describe Beaker::ModuleInstallHelper do
 
   context 'install_module_on' do
     let(:module_source_dir) { '/a/b/c/d' }
+    let(:host) { { 'roles' => %w[master database dashboard classifier] } }
 
     before do
       $module_source_dir = '/a/b/c/d'
@@ -85,8 +86,6 @@ describe Beaker::ModuleInstallHelper do
         .with(host, source: module_source_dir, module_name: 'vcsrepo')
         .and_return(true)
     end
-
-    let(:host) { { 'roles' => %w(master database dashboard classifier) } }
 
     it 'copy module to given host' do
       expect(install_module_on(host)).to be true


### PR DESCRIPTION
Replace .sub! with .sub on line 72

The sub! was replacing the contents of tmp[:module_name] with a nil
value. Updated the call to use .sub instead as we are assigning the
the value of d['name'] where the first '/' found is replaced with '-'.